### PR TITLE
Add GitHub Actions CI workflow for Report Hub

### DIFF
--- a/.github/workflows/app/github-actions-ci.yml
+++ b/.github/workflows/app/github-actions-ci.yml
@@ -1,0 +1,34 @@
+name: Report Hub
+
+on:
+  push:
+    branches: [ '*' ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag report-hub
+
+    - name: Run tests
+      run: docker run -v $(pwd):/app -it report-hub pip install -r requirements-test.txt && pytest --disable-warnings --cov
+
+    - name: Upload coverage to GitHub
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage
+        path: .coverage
+
+    - name: Push the Docker image
+      if: success()
+      run: |
+        docker login docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+        docker tag report-hub docker.pkg.github.com/${{ github.repository }}/report-hub:latest
+        docker tag report-hub docker.pkg.github.com/${{ github.repository }}/report-hub:$(date +%s)
+        docker push docker.pkg.github.com/${{ github.repository }}/report-hub:latest
+        docker push docker.pkg.github.com/${{ github.repository }}/report-hub:$(date +%s)


### PR DESCRIPTION
## Description

<!-- A more detailed description of the change, including the reasons why you are making the change. -->

This pull request adds a GitHub Actions CI workflow for Report Hub, which builds a Docker image, runs tests, uploads coverage to GitHub, and pushes the Docker image to GitHub Packages. This will help ensure that the code is always in a working state and that changes don't break anything.

## Tests Run

<!-- A description of the tests you have run to ensure that the change works correctly. -->

N/A

## Additional Comments

<!-- Any other information that may be relevant to the pull request. -->

Issue: resolve #5
