### PR TITLE
Add Terraform code for creating Azure resources for Report Hub app

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.80.0"
+  constraints = ">= 3.80.0"
+  hashes = [
+    "h1:rcH6Cs2Fbe+gXn0F+AG5+n9Zrcm/AfHyjKr8cJUF7Uw=",
+    "zh:11e3362a3d9ca9d6d57a3c863b26ddcb9e4366c6c99586a4149d2842976e998c",
+    "zh:3005446ee10379e5354b2388d788cad92068ff0988f50e49f6e8eeacdbd6e0a1",
+    "zh:45aa9f9d930e332fc68f2093232edf15ef0d087c9588317371838784382b9dbc",
+    "zh:4e1d57b6b909577b37e85117533eb0d6a2128e7ccfcf88e709ad890f86e67295",
+    "zh:5f777dbb7d72ab83a3a9b9412f8e341573fb34591c834fefa8fc7593e73232a2",
+    "zh:6fab9ea69a2177e29a0c0819f32c51245891fd19b807c4a3e2d4dd5c0a28b8fb",
+    "zh:77b1bdf671a83e17c82b30520312970109811c7725b61fcef69138244d7dd212",
+    "zh:8a1e8d9243f1149b7bcf7b8bda3cf5a1bcea6c709b55053fe7e8cd767dd5f632",
+    "zh:a7c1de65d5f1f241c4d3f30f24912cb9dc8315a1dc7d7bd0814cb4beb1e8f1fb",
+    "zh:b4385e7c84d708cd81647555dd12ade9fb128fd027eb59cd651f4cdcf98a437e",
+    "zh:d4ef3f5b126d5c9766300ffb6f1b3ed091484d46c742cfae2645261e749162e5",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,63 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.80.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  name = "${var.org_name}-${var.solution_name}-${var.environment}"
+}
+
+resource "azurerm_resource_group" "report_hub" {
+  name     = "rg-${local.name}"
+  location = "eastus2"
+}
+
+resource "azurerm_log_analytics_workspace" "report_hub" {
+  name                = "log-${local.name}"
+  location            = azurerm_resource_group.report_hub.location
+  resource_group_name = azurerm_resource_group.report_hub.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_container_app_environment" "report_hub" {
+  name                       = "cae-${local.name}"
+  location                   = azurerm_resource_group.report_hub.location
+  resource_group_name        = azurerm_resource_group.report_hub.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.report_hub.id
+}
+
+resource "azurerm_container_app" "report_hub" {
+  name                         = "ca-${local.name}"
+  container_app_environment_id = azurerm_container_app_environment.report_hub.id
+  resource_group_name          = azurerm_resource_group.report_hub.name
+  revision_mode                = "Single"
+
+  template {
+    container {
+      name   = var.solution_name
+      image  = "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest"
+      cpu    = 0.25
+      memory = "0.5Gi"
+    }
+  }
+
+  secret {
+    name  = "registry-password"
+    value = var.registry_password
+  }
+
+  registry {
+    server               = var.registry_server
+    username             = var.registry_username
+    password_secret_name = "registry-password"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "container_app_fqdn" {
+  value = azurerm_container_app.report_hub.latest_revision_fqdn
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "solution_name" {
+  type        = string
+  description = "The name of the solution"
+  default     = "report-hub"
+}
+
+variable "org_name" {
+  type        = string
+  description = "The name of the organization"
+  default     = "kvncont"
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment where the solution is deployed"
+  default     = "dev"
+}
+
+variable "registry_server" {
+  type        = string
+  description = "Server for the container registry"
+  default     = "ghcr.io"
+}
+
+variable "registry_username" {
+  type        = string
+  description = "Username for the container registry"
+  default     = "kvncont"
+}
+
+variable "registry_password" {
+  type        = string
+  description = "Password for the container registry"
+}


### PR DESCRIPTION
## Description

<!-- A more detailed description of the change, including the reasons why you are making the change. -->

This pull request adds Terraform code for creating Azure resources required for the Report Hub app. The resources include a resource group, a log analytics workspace, a container app environment, and a container app. The code also includes variables for customizing the solution name, organization name, environment, container registry server, username, and password.

## Tests Run

<!-- A description of the tests you have run to ensure that the change works correctly. -->

It was tested in sandbox environment

## Additional Comments

<!-- Any other information that may be relevant to the pull request. -->

Issue: resolve #4 
