### PR TITLE
Add sensitive flag to registry_password variable

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -31,4 +31,5 @@ variable "registry_username" {
 variable "registry_password" {
   type        = string
   description = "Password for the container registry"
+  sensitive   = true
 }


### PR DESCRIPTION
## Description

<!-- A more detailed description of the change, including the reasons why you are making the change. -->

This pull request adds the `sensitive` flag to the `registry_password` variable in order to prevent the password from being displayed in plain text. This is an important security measure that ensures the password is kept confidential.

## Tests Run

<!-- A description of the tests you have run to ensure that the change works correctly. -->

`terraform validate` was success

## Additional Comments

<!-- Any other information that may be relevant to the pull request. -->

Issue resolve #14
