### PR TITLE
Add ingress config for report_hub container app

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -48,6 +48,14 @@ resource "azurerm_container_app" "report_hub" {
   resource_group_name          = azurerm_resource_group.report_hub.name
   revision_mode                = "Single"
 
+  ingress {
+    target_port      = 80
+    external_enabled = true
+    traffic_weight {
+      percentage = 100
+    }
+  }
+
   template {
     container {
       name   = var.solution_name


### PR DESCRIPTION
## Description

<!-- A more detailed description of the change, including the reasons why you are making the change. -->

This pull request adds an ingress configuration for the report_hub container app, allowing external traffic to access the app on port 80. This will improve the app's accessibility and usability.

## Tests Run

<!-- A description of the tests you have run to ensure that the change works correctly. -->

N/A

## Additional Comments

<!-- Any other information that may be relevant to the pull request. -->