### PR TITLE
Update container image reference in main.tf

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -52,7 +52,7 @@ resource "azurerm_container_app" "report_hub" {
   template {
     container {
       name   = var.solution_name
-      image  = "ghcr.io/kvncont/report-hub/report-hub:16.6900694147"
+      image  = "kvncont/report-hub/report-hub:16.6900694147"
       cpu    = 0.25
       memory = "0.5Gi"
     }


### PR DESCRIPTION
## Description

<!-- A more detailed description of the change, including the reasons why you are making the change. -->

This pull request updates the container image reference in the main.tf file to use the correct repository name. The previous reference used the GitHub Container Registry (ghcr.io) prefix, which is not necessary for this repository. This change ensures that the container image is correctly pulled from the Docker Hub registry.


## Tests Run

<!-- A description of the tests you have run to ensure that the change works correctly. -->

N/A

## Additional Comments

<!-- Any other information that may be relevant to the pull request. -->

N/A