### PR TITLE
Update container image source to ghcr.io

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -52,7 +52,7 @@ resource "azurerm_container_app" "report_hub" {
   template {
     container {
       name   = var.solution_name
-      image  = "kvncont/report-hub/report-hub:16.6900694147"
+      image  = "ghcr.io/kvncont/report-hub/report-hub:16.6900694147"
       cpu    = 0.25
       memory = "0.5Gi"
     }


### PR DESCRIPTION
## Description

<!-- A more detailed description of the change, including the reasons why you are making the change. -->

This pull request updates the container image source for the `report_hub` resource in the `azurerm_container_app` module to use `ghcr.io` instead of the previous source. This change ensures that the container image is pulled from the correct registry.

No issues were encountered during the update.

## Tests Run

<!-- A description of the tests you have run to ensure that the change works correctly. -->

N/A

## Additional Comments

<!-- Any other information that may be relevant to the pull request. -->

N/A