### PR TITLE
Update port number in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,4 @@ USER fastapi
 EXPOSE 80
 
 # Run the application with Uvicorn
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80", "--log-config", "log_conf.yml"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--log-config", "log_conf.yml"]


### PR DESCRIPTION
## Description

<!-- A more detailed description of the change, including the reasons why you are making the change. -->

This pull request updates the port number in the Dockerfile to address the issue of denied access to port 80 in container apps. The new port number is set to 8000. This change ensures that the application can be accessed without any port conflicts.

## Tests Run

<!-- A description of the tests you have run to ensure that the change works correctly. -->

Run in sandbox environment

## Additional Comments

<!-- Any other information that may be relevant to the pull request. -->

Issue: resolved #27