### PR TITLE
Update target port and container image version in main.tf

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,20 +42,23 @@ resource "azurerm_container_app" "report_hub" {
   revision_mode                = "Single"
 
   ingress {
-    target_port      = 80
+    target_port      = 8000
     external_enabled = true
     traffic_weight {
-      percentage = 100
+      percentage      = 100
+      latest_revision = true
     }
   }
 
   template {
     container {
       name   = var.solution_name
-      image  = "ghcr.io/kvncont/report-hub/report-hub:16.6900694147"
+      image  = "ghcr.io/kvncont/report-hub/report-hub:17.6912200169"
       cpu    = 0.25
       memory = "0.5Gi"
     }
+    min_replicas = 0
+    max_replicas = 2
   }
 
   secret {


### PR DESCRIPTION
## Description

<!-- A more detailed description of the change, including the reasons why you are making the change. -->

This pull request updates the target port in the main.tf file to 8000 and the container image version to "ghcr.io/kvncont/report-hub/report-hub:17.6912200169". Additionally, it sets the traffic weight percentage to 100 and enables the latest revision. The min_replicas and max_replicas are also set to 0 and 2 respectively. These changes ensure that the application runs on the desired port and uses the updated container image version.

## Tests Run

<!-- A description of the tests you have run to ensure that the change works correctly. -->

Run in sandbox environment

## Additional Comments

<!-- Any other information that may be relevant to the pull request. -->

Issue: #4